### PR TITLE
Enable strict option in koa router

### DIFF
--- a/app.js
+++ b/app.js
@@ -17,7 +17,7 @@ const views = require('koa-views');
  */
 
 const app = new Koa();
-const router = new Router();
+const router = new Router({ strict: true });
 const {
   PORT = 3000,
   SESSION_SECRET


### PR DESCRIPTION
Forces the main page to be served with a trailing slash. This is needed to be able to use relative paths in the templates since the app may be hosted in a subpath (`http://foobar.com/subpath/`).