### PR TITLE
Fix GitHub authentication

### DIFF
--- a/src/app.js
+++ b/src/app.js
@@ -32,7 +32,7 @@ router
     await context.render('index.html');
   })
   .get('/github', passport.authenticate('github', {
-    scope: ['user:email', 'read:org'],
+    scope: ['user:email', 'read:org', 'repo'],
     successReturnToOrRedirect: './'
   }))
   .get('/strap.sh', async context => {


### PR DESCRIPTION
Fixes HTTPs authentication with GitHub which prevented a clean run of the strap script since the `dotfiles` repo couldn't actually be cloned.